### PR TITLE
refactor: update events that trigger ci-cd workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    branches: -main
 
 permissions:
   actions: read


### PR DESCRIPTION
Previously, all PR events run the ci-cd workflow. This is not optimal because the main job runs several commands on NxCloud that can become costly in the future.

This PR updates events that trigger the workflow, specifying that only `pull-requests` on `main` should run the workflow `ci-cd`.